### PR TITLE
Start logging time for render and message display

### DIFF
--- a/Gist/EngineWeb/EngineWeb.swift
+++ b/Gist/EngineWeb/EngineWeb.swift
@@ -36,7 +36,7 @@ public class EngineWeb: NSObject {
     init(configuration: EngineWebConfiguration) {
         super.init()
 
-        _elapsedTimer.start(title: configuration.messageId)
+        _elapsedTimer.start(title: "Engine render for message: \(configuration.messageId)")
         
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.navigationDelegate = self
@@ -109,7 +109,7 @@ extension EngineWeb: WKScriptMessageHandler {
             }
         case .routeChanged:
             if let route = EngineEventHandler.getRouteChangedProperties(properties: eventProperties) {
-                _elapsedTimer.start(title: route)
+                _elapsedTimer.start(title: "Engine render for message: \(route)")
                 delegate?.routeChanged(newRoute: route)
             }
         case .routeError:

--- a/Gist/EngineWeb/EngineWeb.swift
+++ b/Gist/EngineWeb/EngineWeb.swift
@@ -15,6 +15,7 @@ public protocol EngineWebDelegate: AnyObject {
 public class EngineWeb: NSObject {
     private var _currentRoute = ""
     private var _timeoutTimer: Timer?
+    private var _elapsedTimer = ElapsedTimer()
 
     weak public var delegate: EngineWebDelegate?
     var webView = WKWebView()
@@ -35,6 +36,8 @@ public class EngineWeb: NSObject {
     init(configuration: EngineWebConfiguration) {
         super.init()
 
+        _elapsedTimer.start(title: configuration.messageId)
+        
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.navigationDelegate = self
         webView.isOpaque = false
@@ -100,11 +103,13 @@ extension EngineWeb: WKScriptMessageHandler {
             _timeoutTimer?.invalidate()
             delegate?.bootstrapped()
         case .routeLoaded:
+            _elapsedTimer.end()
             if let route = EngineEventHandler.getRouteLoadedProperties(properties: eventProperties) {
                 delegate?.routeLoaded(route: route)
             }
         case .routeChanged:
             if let route = EngineEventHandler.getRouteChangedProperties(properties: eventProperties) {
+                _elapsedTimer.start(title: route)
                 delegate?.routeChanged(newRoute: route)
             }
         case .routeError:

--- a/Gist/Managers/MessageManager.swift
+++ b/Gist/Managers/MessageManager.swift
@@ -8,7 +8,6 @@ public enum GistMessageActions: String {
 class MessageManager: EngineWebDelegate {
     private var engine: EngineWeb?
     private let siteId: String
-    private var shouldShowMessage = false
     private var messagePosition: MessagePosition = .top
     private var messageLoaded = false
     private var modalViewManager: ModalViewManager?
@@ -16,6 +15,7 @@ class MessageManager: EngineWebDelegate {
     let currentMessage: Message
     var gistView: GistView!
     private var currentRoute: String
+    private var elapsedTimer = ElapsedTimer()
     weak var delegate: GistDelegate?
 
     init(siteId: String, message: Message) {
@@ -38,8 +38,8 @@ class MessageManager: EngineWebDelegate {
     }
 
     func showMessage(position: MessagePosition) {
+        elapsedTimer.start(title: "Displaying modal for message: \(currentMessage.messageId)")
         messagePosition = position
-        shouldShowMessage = true
     }
 
     func getMessageView() -> GistView {
@@ -53,6 +53,7 @@ class MessageManager: EngineWebDelegate {
             modalViewManager?.showModalView { [weak self] in
                 guard let self = self else { return }
                 self.delegate?.messageShown(message: self.currentMessage)
+                self.elapsedTimer.end()
             }
         }
     }

--- a/Gist/Network/Utilities/ElapsedTimer.swift
+++ b/Gist/Network/Utilities/ElapsedTimer.swift
@@ -14,7 +14,7 @@ class ElapsedTimer {
             return
         }
         let timeElapsed = ((CFAbsoluteTimeGetCurrent() - startTime) * 1000).rounded() / 1000.0
-        Logger.instance.info(message: "Timer \(title) elapsed in \(timeElapsed) seconds")
+        Logger.instance.info(message: "\(title) timer elapsed in \(timeElapsed) seconds")
         self.startTime = nil
     }
 }

--- a/Gist/Network/Utilities/ElapsedTimer.swift
+++ b/Gist/Network/Utilities/ElapsedTimer.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+class ElapsedTimer {
+    private var title: String?
+    private var startTime: CFAbsoluteTime?
+    
+    func start(title: String) {
+        self.title = title
+        startTime = CFAbsoluteTimeGetCurrent()
+    }
+    
+    func end() {
+        guard let startTime = startTime, let title = title else {
+            return
+        }
+        let timeElapsed = ((CFAbsoluteTimeGetCurrent() - startTime) * 1000).rounded() / 1000.0
+        Logger.instance.info(message: "Timer \(title) elapsed in \(timeElapsed) seconds")
+        self.startTime = nil
+    }
+}


### PR DESCRIPTION
As part of the rendering performance updates we need to start measuring the time it takes to render a message.

Part of: https://github.com/customerio/issues/issues/9268