### PR TITLE
Reverts persistent system actions behaviour

### DIFF
--- a/Gist/Managers/MessageManager.swift
+++ b/Gist/Managers/MessageManager.swift
@@ -117,12 +117,8 @@ class MessageManager: EngineWebDelegate {
                 if let url = URL(string: action), UIApplication.shared.canOpenURL(url) {
                     UIApplication.shared.open(url) { handled in
                         if handled {
-                            if let persistent = self.currentMessage.gistProperties.persistent, persistent {
-                                Logger.instance.info(message: "Message is persistent, not dismissing.")
-                            } else {
-                                Logger.instance.info(message: "Dismissing from system action: \(action)")
-                                self.dismissMessage()
-                            }
+                            Logger.instance.info(message: "Dismissing from system action: \(action)")
+                            self.dismissMessage()
                         } else {
                             Logger.instance.info(message: "System action not handled")
                         }


### PR DESCRIPTION
After our sync call yesterday I realized that not dismissing a message after a "system action" is a terrible idea as it would keep the message active if a deep link is performed on the same app.

This reverts the behavior back to dismissing the message and keeping it in the queue until actually dismissed.